### PR TITLE
Fix crash when using with Biomes O Plenty.

### DIFF
--- a/src/main/java/mariot7/xlfoodmod/world/WorldGenGrassxlfoodmod.java
+++ b/src/main/java/mariot7/xlfoodmod/world/WorldGenGrassxlfoodmod.java
@@ -5,6 +5,7 @@ import java.util.Random;
 import mariot7.xlfoodmod.init.BlockListxlfoodmod;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
+import net.minecraft.block.state.IBlockState;
 import net.minecraft.init.Blocks;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
@@ -20,8 +21,8 @@ public class WorldGenGrassxlfoodmod extends WorldGenerator {
 		if(y >= pos.getY())
 		{
 			BlockPos bushPos = new BlockPos(pos.getX(), y, pos.getZ());
-			Block toReplace = worldIn.getBlockState(bushPos).getBlock();
-			if(toReplace == Blocks.AIR || toReplace.getMaterial(null) == Material.PLANTS)
+			IBlockState toReplace = worldIn.getBlockState(bushPos);
+			if(toReplace.getBlock() == Blocks.AIR || toReplace.getMaterial() == Material.PLANTS)
 			{
 				worldIn.setBlockState(bushPos, grass.getDefaultState(), 2);
 			}  


### PR DESCRIPTION
Use IBlockState.getMaterial() rather than deprecated Block.getMaterial(null).

[crash-2017-08-25_20.37.27-server.txt](https://github.com/mariot7/XL-Food-Mod/files/1253329/crash-2017-08-25_20.37.27-server.txt)
