### PR TITLE
Made dough ingredients Forge Oredict compatible

### DIFF
--- a/src/main/resources/assets/xlfoodmod/recipes/dough.json
+++ b/src/main/resources/assets/xlfoodmod/recipes/dough.json
@@ -1,19 +1,22 @@
 {
-	"type": "minecraft:crafting_shaped",
+	"result": {
+		"item": "xlfoodmod:dough",
+		"count": 8
+	},
 	"pattern": [
 		"WW",
 		"WW",
 		" B"
 	],
+	"type": "minecraft:crafting_shaped",
 	"key": {
 		"W": {
-			"item": "minecraft:wheat"
-		},
+			"item": "cropWheat",
+			"type": "forge:ore_dict",
 		"B": {
-			"item": "minecraft:water_bucket"
+			"item": "listAllWater",
+			"type": "forge:ore_dict"
 		}
-	},
-	"result": {
-		"item": "xlfoodmod:dough", "count": 8
 	}
+}
 }

--- a/src/main/resources/assets/xlfoodmod/recipes/dough.json
+++ b/src/main/resources/assets/xlfoodmod/recipes/dough.json
@@ -12,11 +12,11 @@
 	"key": {
 		"W": {
 			"item": "cropWheat",
-			"type": "forge:ore_dict",
+			"type": "forge:ore_dict"
+		},
 		"B": {
 			"item": "listAllWater",
 			"type": "forge:ore_dict"
 		}
 	}
-}
 }


### PR DESCRIPTION
I've done this in order to give Cooking For Blockheads Sink the capability to provide water for dough. This was the primary concern in our ATM3 Remix modpack regarding recipes, but in the future I'd hope to push similar changes to the rest of the current recipes.